### PR TITLE
Fan and entity data

### DIFF
--- a/docs/page-nodes.md
+++ b/docs/page-nodes.md
@@ -59,13 +59,36 @@ Page item related data must be sent using the _data_ topic.
 {
     "topic": "data",
     "payload": {
-        "entityId": "<id of entity specified in configuration>"
-        // <... further data ...>
+        "entityId": "<id of entity specified in configuration>",
+        "icon": "<optional, icon to display>",
+        "iconColor": "<optional, #rrggbb or rgb(r,g,b)>",
+        "text": "<optional, text to be shown>"
+        // <... further entity-specific data ...>
     }
 }
 ```
 
 Additional data must be specified depending on the entity type.
+
+#### Fan-specific payload data
+
+```json
+{
+    "topic": "data",
+    "payload": {
+        // <... general entity data ...>
+        "speed": "<fanSpeedLevel as configured for entity>",
+        "active": "<active>",
+        "mode": "<name of configured mode>"
+    }
+}
+```
+
+| Key      | Description                                                                          |
+| -------- | ------------------------------------------------------------------------------------ |
+| `speed`  | speed level in range as configured for entity                                        |
+| `active` | [ `false` \| `0` \| `'0'`] for off, and [`true` \| `1` \| `'1'`] for on respectively |
+| `mode`   | name of active mode as configured for entity                                         |
 
 ## Entities Node
 

--- a/src/lib/entities-page-node.ts
+++ b/src/lib/entities-page-node.ts
@@ -121,16 +121,17 @@ export class EntitiesPageNode<TConfig extends EntityBasedPageConfig> extends Pag
         for (let i = 0; i < maxEntities; i += 1) {
             const entityConfig = entities[i]
             const entityData = this.getEntityData(entityConfig.entityId)
-            const optionalValue = entityData?.value ?? entityConfig.optionalValue
 
             const icon = entityData?.icon ?? entityConfig.icon
+            const iconColor = entityData?.iconColor ?? entityConfig.icon
             const text = entityData?.text ?? entityConfig.text
+            const optionalValue = entityData?.value ?? entityConfig.optionalValue
 
             const entity = NSPanelUtils.makeEntity(
                 entityConfig.type,
                 entityConfig.entityId,
                 NSPanelUtils.getIcon(icon ?? ''),
-                NSPanelColorUtils.toHmiColor(entityConfig.iconColor ?? NSPanelConstants.DEFAULT_LUI_COLOR),
+                NSPanelColorUtils.toHmiColor(iconColor),
                 text ?? '',
                 optionalValue
             )

--- a/src/lib/nspanel-popup-helpers.ts
+++ b/src/lib/nspanel-popup-helpers.ts
@@ -99,11 +99,19 @@ export class NSPanelPopupHelpers {
         const fanEntityData: FanEntityData = <FanEntityData>entityData
         const result: HMICommandParameters = []
 
+        const fanSpeedNum = NSPanelUtils.limitNumberToRange(
+            fanEntityData?.speed ?? entity.min,
+            entity.min,
+            entity.max,
+            0
+        )
+        const fanSpeed = fanEntityData?.speed != null ? fanSpeedNum : NSPanelConstants.STR_EMPTY
+
         result.push(entity.entityId)
         result.push(NSPanelUtils.getIcon(entity.icon ?? NSPanelConstants.STR_EMPTY))
         result.push(NSPanelColorUtils.toHmiColor(entity.iconColor ?? NSPanelConstants.DEFAULT_LUI_COLOR))
         result.push(NSPanelUtils.toHmiState(fanEntityData?.active ?? 0))
-        result.push(fanEntityData?.speed ?? NSPanelConstants.STR_EMPTY)
+        result.push(fanSpeed)
         result.push(entity.max ?? NSPanelConstants.STR_EMPTY)
         result.push(fanEntityData?.text ?? NSPanelConstants.STR_EMPTY)
         result.push(fanEntityData?.mode ?? NSPanelConstants.STR_EMPTY) // current mode value

--- a/src/resources/nspanel-lui.ts
+++ b/src/resources/nspanel-lui.ts
@@ -478,8 +478,7 @@ type EventMappingContainer = import('../types/nspanel-lui-editor').EventMappingC
                     self.notifyChange(entity, 'remove')
                 },
 
-                sortItems(_events) {
-                },
+                sortItems(_events) {},
 
                 sortable: true,
                 removable: true,


### PR DESCRIPTION
- preferably use icon color from entity data
- fan message data added to docs
- limit fan speed data to configured range