### PR TITLE
Fix typo in thermo page comment

### DIFF
--- a/src/nodes/nspanel-page-thermo.ts
+++ b/src/nodes/nspanel-page-thermo.ts
@@ -305,7 +305,7 @@ module.exports = (RED) => {
                             for (let key in msg.payload) {
                                 if (Object.prototype.hasOwnProperty.call(this.data, key)) {
                                     this.data[key] = msg.payload[key]
-                                    inputHandled.handled = true // TODO: there might be undhandled data
+                                    inputHandled.handled = true // TODO: there might be unhandled data
                                     dirty = true
                                 }
                             }


### PR DESCRIPTION
## Summary
- correct a typo in a comment in `nspanel-page-thermo.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873d088cb5c83208d7e9f21abfd3c94